### PR TITLE
Extend GitHub OAuth requirement to ALL agents in SWE Agent Selection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# GitHub App Configuration
+GITHUB_APP_ID=1866067
+GITHUB_CLIENT_ID=Iv23liJ8gCLvAnruP9KV
+GITHUB_CLIENT_SECRET=your_github_client_secret_here
+GITHUB_PRIVATE_KEY_PATH=/path/to/private/key.pem
+GITHUB_REDIRECT_URI=http://localhost:5174/auth/callback
+
+# Production URLs
+GITHUB_REDIRECT_URI_PROD=https://aifoundry.app/auth/github/callback

--- a/src/backend/app/github_app.py
+++ b/src/backend/app/github_app.py
@@ -1,0 +1,63 @@
+import os
+import jwt
+import time
+import httpx
+from typing import Optional, Dict, Any
+from fastapi import HTTPException
+import logging
+
+logger = logging.getLogger(__name__)
+
+class GitHubAppClient:
+    def __init__(self):
+        self.app_id = os.getenv("GITHUB_APP_ID", "1866067")
+        self.client_id = os.getenv("GITHUB_CLIENT_ID", "Iv23liJ8gCLvAnruP9KV")
+        self.private_key_path = os.getenv("GITHUB_PRIVATE_KEY_PATH", "/home/ubuntu/attachments/c88b6cde-e965-426e-9bbd-3ac7433d9557/aifoundry-app.2025-08-29.private-key.pem")
+        
+    def generate_jwt_token(self) -> str:
+        """Generate JWT token for GitHub App authentication"""
+        with open(self.private_key_path, 'r') as key_file:
+            private_key = key_file.read()
+        
+        now = int(time.time())
+        payload = {
+            'iat': now - 60,
+            'exp': now + (10 * 60),
+            'iss': self.app_id
+        }
+        
+        return jwt.encode(payload, private_key, algorithm='RS256')
+    
+    async def get_installation_token(self, installation_id: str) -> str:
+        """Get installation access token for a specific installation"""
+        jwt_token = self.generate_jwt_token()
+        
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                f"https://api.github.com/app/installations/{installation_id}/access_tokens",
+                headers={
+                    "Authorization": f"Bearer {jwt_token}",
+                    "Accept": "application/vnd.github.v3+json"
+                }
+            )
+            
+            if response.status_code == 201:
+                return response.json()["token"]
+            else:
+                raise HTTPException(status_code=response.status_code, detail=f"Failed to get installation token: {response.text}")
+    
+    async def fork_repository(self, installation_token: str, owner: str, repo: str, new_owner: str) -> Dict[str, Any]:
+        """Fork a repository to the authenticated user's account"""
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                f"https://api.github.com/repos/{owner}/{repo}/forks",
+                headers={
+                    "Authorization": f"token {installation_token}",
+                    "Accept": "application/vnd.github.v3+json"
+                }
+            )
+            
+            if response.status_code == 202:
+                return response.json()
+            else:
+                raise HTTPException(status_code=response.status_code, detail=f"Failed to fork repository: {response.text}")

--- a/src/backend/app/github_app.py
+++ b/src/backend/app/github_app.py
@@ -10,9 +10,16 @@ logger = logging.getLogger(__name__)
 
 class GitHubAppClient:
     def __init__(self):
-        self.app_id = os.getenv("GITHUB_APP_ID", "1866067")
-        self.client_id = os.getenv("GITHUB_CLIENT_ID", "Iv23liJ8gCLvAnruP9KV")
-        self.private_key_path = os.getenv("GITHUB_PRIVATE_KEY_PATH", "/home/ubuntu/attachments/c88b6cde-e965-426e-9bbd-3ac7433d9557/aifoundry-app.2025-08-29.private-key.pem")
+        self.app_id = os.getenv("GITHUB_APP_ID")
+        self.client_id = os.getenv("GITHUB_CLIENT_ID")
+        self.private_key_path = os.getenv("GITHUB_PRIVATE_KEY_PATH")
+        
+        if not self.app_id:
+            raise ValueError("GITHUB_APP_ID environment variable is required")
+        if not self.client_id:
+            raise ValueError("GITHUB_CLIENT_ID environment variable is required")
+        if not self.private_key_path:
+            raise ValueError("GITHUB_PRIVATE_KEY_PATH environment variable is required")
         
     def generate_jwt_token(self) -> str:
         """Generate JWT token for GitHub App authentication"""

--- a/src/backend/app/main.py
+++ b/src/backend/app/main.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI, Query, HTTPException
+from fastapi import FastAPI, Query, HTTPException, Header
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 from typing import List, Optional, Dict
@@ -12,6 +12,8 @@ from datetime import datetime
 from azure.ai.projects import AIProjectClient
 from azure.core.credentials import AzureKeyCredential
 from .mcp_client import create_github_mcp_client
+from .github_app import GitHubAppClient
+from .github_app import GitHubAppClient
 
 # Load environment variables
 from dotenv import load_dotenv
@@ -154,6 +156,90 @@ def save_specs(specs: List[Spec]):
 
 specs_data: List[Spec] = load_specs()
 spec_by_id: Dict[str, Spec] = {s.id: s for s in specs_data}
+
+github_app_client = GitHubAppClient()
+
+@app.get("/api/auth/github")
+async def github_oauth_login():
+    """Initiate GitHub OAuth flow"""
+    client_id = os.getenv("GITHUB_CLIENT_ID", "Iv23liJ8gCLvAnruP9KV")
+    redirect_uri = os.getenv("GITHUB_REDIRECT_URI", "http://localhost:5173/auth/callback")
+    scope = "repo,workflow,admin:repo_hook"
+    
+    auth_url = f"https://github.com/login/oauth/authorize?client_id={client_id}&redirect_uri={redirect_uri}&scope={scope}"
+    return {"auth_url": auth_url}
+
+@app.post("/api/auth/github/callback")
+async def github_oauth_callback(request: Dict[str, str]):
+    """Handle GitHub OAuth callback"""
+    code = request.get("code")
+    if not code:
+        raise HTTPException(status_code=400, detail="No authorization code provided")
+    
+    client_id = os.getenv("GITHUB_CLIENT_ID", "Iv23liJ8gCLvAnruP9KV")
+    client_secret = os.getenv("GITHUB_CLIENT_SECRET")
+    
+    if not client_secret:
+        raise HTTPException(status_code=500, detail="GitHub client secret not configured")
+    
+    async with httpx.AsyncClient() as client:
+        token_response = await client.post(
+            "https://github.com/login/oauth/access_token",
+            data={
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "code": code
+            },
+            headers={"Accept": "application/json"}
+        )
+        
+        if token_response.status_code != 200:
+            raise HTTPException(status_code=400, detail="Failed to exchange code for token")
+        
+        token_data = token_response.json()
+        access_token = token_data.get("access_token")
+        
+        if not access_token:
+            raise HTTPException(status_code=400, detail="No access token received")
+        
+        user_response = await client.get(
+            "https://api.github.com/user",
+            headers={"Authorization": f"token {access_token}"}
+        )
+        
+        if user_response.status_code != 200:
+            raise HTTPException(status_code=400, detail="Failed to get user information")
+        
+        user_data = user_response.json()
+        
+        return {
+            "access_token": access_token,
+            "user": {
+                "login": user_data["login"],
+                "name": user_data.get("name"),
+                "avatar_url": user_data["avatar_url"]
+            }
+        }
+
+@app.get("/api/user/repositories")
+async def get_user_repositories(authorization: str = Header(...)):
+    """Get user's repositories"""
+    if not authorization.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Invalid authorization header")
+    
+    token = authorization.split(" ")[1]
+    
+    async with httpx.AsyncClient() as client:
+        response = await client.get(
+            "https://api.github.com/user/repos",
+            headers={"Authorization": f"token {token}"},
+            params={"sort": "updated", "per_page": 100}
+        )
+        
+        if response.status_code != 200:
+            raise HTTPException(status_code=response.status_code, detail="Failed to fetch repositories")
+        
+        return response.json()
 
 @app.get("/api/specs")
 async def get_specs():
@@ -1439,7 +1525,12 @@ Please implement these customizations following best practices and maintaining c
                     
                     pr_title = f"Implement {item['title']} {item_type} customizations for {request.customization.company_name}"
                     
-                    mcp_client = create_github_mcp_client()
+                    auth_method = "oauth" if request.api_key and len(request.api_key) > 40 else "pat"
+                    
+                    mcp_client = create_github_mcp_client(
+                        auth_method=auth_method,
+                        github_token=request.api_key
+                    )
                     result = await mcp_client.create_pull_request_with_copilot(
                         owner=owner,
                         repo=repo,
@@ -1505,3 +1596,130 @@ Please implement these customizations following best practices and maintaining c
         raise HTTPException(status_code=500, detail=f"Network error: {str(e)}")
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Error assigning to SWE agent: {str(e)}")
+
+@app.post("/api/templates/{template_id}/deploy")
+async def deploy_template_to_github(template_id: str, request: dict):
+    """Deploy template to user's GitHub repository with agent configuration"""
+    try:
+        template = next((t for t in templates_data if t["id"] == template_id), None)
+        if not template:
+            raise HTTPException(status_code=404, detail="Template not found")
+        
+        access_token = request.get("access_token")
+        target_repo = request.get("target_repo")
+        agent_config = request.get("agent_config", {})
+        
+        if not access_token or not target_repo:
+            raise HTTPException(status_code=400, detail="Missing access_token or target_repo")
+        
+        import re
+        match = re.search(r'github\.com/([^/]+)/([^/]+?)(?:\.git)?/?$', template["github_url"])
+        if not match:
+            raise HTTPException(status_code=400, detail="Invalid template GitHub URL")
+        
+        template_owner, template_repo = match.groups()
+        
+        async with httpx.AsyncClient() as client:
+            fork_response = await client.post(
+                f"https://api.github.com/repos/{template_owner}/{template_repo}/forks",
+                headers={
+                    "Authorization": f"token {access_token}",
+                    "Accept": "application/vnd.github.v3+json"
+                },
+                json={"name": target_repo}
+            )
+            
+            if fork_response.status_code not in [202, 201]:
+                raise HTTPException(status_code=fork_response.status_code, detail=f"Failed to fork repository: {fork_response.text}")
+            
+            fork_data = fork_response.json()
+            
+            user_response = await client.get(
+                "https://api.github.com/user",
+                headers={"Authorization": f"token {access_token}"}
+            )
+            user_data = user_response.json()
+            user_login = user_data["login"]
+            
+            import asyncio
+            await asyncio.sleep(2)
+            
+            from datetime import datetime
+            agent_config_content = {
+                "template_id": template_id,
+                "template_name": template["title"],
+                "agent_config": agent_config,
+                "deployment_date": datetime.now().isoformat(),
+                "source_repo": template["github_url"]
+            }
+            
+            import base64
+            import json
+            config_response = await client.put(
+                f"https://api.github.com/repos/{user_login}/{target_repo}/contents/aifoundry-agents.json",
+                headers={
+                    "Authorization": f"token {access_token}",
+                    "Accept": "application/vnd.github.v3+json"
+                },
+                json={
+                    "message": "Add AIfoundry agent configuration",
+                    "content": base64.b64encode(
+                        json.dumps(agent_config_content, indent=2).encode()
+                    ).decode()
+                }
+            )
+            
+            workflow_content = f"""name: AIfoundry Agent Workflow
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+
+jobs:
+  agent-execution:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Setup Agent Environment
+      run: |
+        echo "Setting up agent environment for {template['title']}"
+        echo "Agent config: {agent_config.get('agent_type', 'default')}"
+    
+    - name: Execute Agent Tasks
+      run: |
+        echo "Executing agent tasks..."
+        
+    - name: Report Results
+      run: |
+        echo "Agent execution completed"
+"""
+            
+            workflow_response = await client.put(
+                f"https://api.github.com/repos/{user_login}/{target_repo}/contents/.github/workflows/aifoundry-agent.yml",
+                headers={
+                    "Authorization": f"token {access_token}",
+                    "Accept": "application/vnd.github.v3+json"
+                },
+                json={
+                    "message": "Add AIfoundry agent workflow",
+                    "content": base64.b64encode(workflow_content.encode()).decode()
+                }
+            )
+            
+            return {
+                "status": "success",
+                "message": f"Successfully deployed {template['title']} to {user_login}/{target_repo}",
+                "repository": {
+                    "name": target_repo,
+                    "full_name": f"{user_login}/{target_repo}",
+                    "url": fork_data["html_url"]
+                },
+                "agent_config": agent_config_content
+            }
+            
+    except Exception as e:
+        logger.error(f"Error deploying template to GitHub: {e}")
+        raise HTTPException(status_code=500, detail=str(e))

--- a/src/backend/app/main.py
+++ b/src/backend/app/main.py
@@ -162,8 +162,14 @@ github_app_client = GitHubAppClient()
 @app.get("/api/auth/github")
 async def github_oauth_login():
     """Initiate GitHub OAuth flow"""
-    client_id = os.getenv("GITHUB_CLIENT_ID", "Iv23liJ8gCLvAnruP9KV")
-    redirect_uri = os.getenv("GITHUB_REDIRECT_URI", "http://localhost:5173/auth/callback")
+    client_id = os.getenv("GITHUB_CLIENT_ID")
+    redirect_uri = os.getenv("GITHUB_REDIRECT_URI")
+    
+    if not client_id:
+        raise HTTPException(status_code=500, detail="GITHUB_CLIENT_ID environment variable is required")
+    if not redirect_uri:
+        raise HTTPException(status_code=500, detail="GITHUB_REDIRECT_URI environment variable is required")
+    
     scope = "repo,workflow,admin:repo_hook"
     
     auth_url = f"https://github.com/login/oauth/authorize?client_id={client_id}&redirect_uri={redirect_uri}&scope={scope}"
@@ -176,11 +182,13 @@ async def github_oauth_callback(request: Dict[str, str]):
     if not code:
         raise HTTPException(status_code=400, detail="No authorization code provided")
     
-    client_id = os.getenv("GITHUB_CLIENT_ID", "Iv23liJ8gCLvAnruP9KV")
+    client_id = os.getenv("GITHUB_CLIENT_ID")
     client_secret = os.getenv("GITHUB_CLIENT_SECRET")
     
+    if not client_id:
+        raise HTTPException(status_code=500, detail="GITHUB_CLIENT_ID environment variable is required")
     if not client_secret:
-        raise HTTPException(status_code=500, detail="GitHub client secret not configured")
+        raise HTTPException(status_code=500, detail="GITHUB_CLIENT_SECRET environment variable is required")
     
     async with httpx.AsyncClient() as client:
         token_response = await client.post(

--- a/src/backend/app/main.py
+++ b/src/backend/app/main.py
@@ -1525,7 +1525,7 @@ Please implement these customizations following best practices and maintaining c
                     
                     pr_title = f"Implement {item['title']} {item_type} customizations for {request.customization.company_name}"
                     
-                    auth_method = "oauth" if request.api_key and len(request.api_key) > 40 else "pat"
+                    auth_method = "oauth"
                     
                     mcp_client = create_github_mcp_client(
                         auth_method=auth_method,

--- a/src/backend/app/mcp_client.py
+++ b/src/backend/app/mcp_client.py
@@ -19,21 +19,21 @@ logger = logging.getLogger(__name__)
 class GitHubMCPClient:
     """Client for interacting with GitHub MCP server and Copilot coding agent."""
     
-    def __init__(self, auth_method: str = "pat", github_pat: Optional[str] = None):
+    def __init__(self, auth_method: str = "pat", github_token: Optional[str] = None):
         """
         Initialize the GitHub MCP client.
         
         Args:
             auth_method: Authentication method ("pat" or "oauth")
-            github_pat: GitHub Personal Access Token (required for PAT auth)
+            github_token: GitHub Personal Access Token or OAuth token
         """
         self.auth_method = auth_method
-        self.github_pat = github_pat or os.getenv("GITHUB_PAT")
+        self.github_token = github_token or os.getenv("GITHUB_PAT")
         self.server_url = "https://api.githubcopilot.com/mcp/x/copilot"
         self.session: Optional[ClientSession] = None
         
-        if self.auth_method == "pat" and not self.github_pat:
-            raise ValueError("GitHub PAT is required for PAT authentication")
+        if not self.github_token:
+            raise ValueError("GitHub token is required for authentication")
     
     async def connect(self) -> bool:
         """
@@ -45,7 +45,7 @@ class GitHubMCPClient:
         try:
             if self.auth_method == "pat":
                 headers = {
-                    "Authorization": f"Bearer {self.github_pat}",
+                    "Authorization": f"Bearer {self.github_token}",
                     "Content-Type": "application/json",
                     "X-MCP-Toolsets": "copilot"
                 }
@@ -84,7 +84,7 @@ class GitHubMCPClient:
         try:
             if self.auth_method == "pat":
                 headers = {
-                    "Authorization": f"Bearer {self.github_pat}",
+                    "Authorization": f"Bearer {self.github_token}",
                     "Content-Type": "application/json",
                     "X-MCP-Toolsets": "copilot"
                 }
@@ -148,7 +148,7 @@ class GitHubMCPClient:
             
             if self.auth_method == "pat":
                 headers = {
-                    "Authorization": f"Bearer {self.github_pat}",
+                    "Authorization": f"Bearer {self.github_token}",
                     "Content-Type": "application/json",
                     "X-MCP-Toolsets": "copilot"
                 }
@@ -197,19 +197,19 @@ class GitHubMCPClient:
 
 def create_github_mcp_client(
     auth_method: Optional[str] = None,
-    github_pat: Optional[str] = None
+    github_token: Optional[str] = None
 ) -> GitHubMCPClient:
     """
     Factory function to create a GitHub MCP client.
     
     Args:
         auth_method: Authentication method ("pat" or "oauth")
-        github_pat: GitHub Personal Access Token
+        github_token: GitHub Personal Access Token or OAuth token
         
     Returns:
         GitHubMCPClient instance
     """
     auth_method = auth_method or os.getenv("MCP_AUTH_METHOD", "pat")
-    github_pat = github_pat or os.getenv("GITHUB_PAT")
+    github_token = github_token or os.getenv("GITHUB_PAT")
     
-    return GitHubMCPClient(auth_method=auth_method, github_pat=github_pat)
+    return GitHubMCPClient(auth_method=auth_method, github_token=github_token)

--- a/src/backend/app/mcp_client.py
+++ b/src/backend/app/mcp_client.py
@@ -19,16 +19,16 @@ logger = logging.getLogger(__name__)
 class GitHubMCPClient:
     """Client for interacting with GitHub MCP server and Copilot coding agent."""
     
-    def __init__(self, auth_method: str = "pat", github_token: Optional[str] = None):
+    def __init__(self, auth_method: str = "oauth", github_token: Optional[str] = None):
         """
         Initialize the GitHub MCP client.
         
         Args:
-            auth_method: Authentication method ("pat" or "oauth")
-            github_token: GitHub Personal Access Token or OAuth token
+            auth_method: Authentication method ("oauth")
+            github_token: GitHub OAuth token
         """
         self.auth_method = auth_method
-        self.github_token = github_token or os.getenv("GITHUB_PAT")
+        self.github_token = github_token
         self.server_url = "https://api.githubcopilot.com/mcp/x/copilot"
         self.session: Optional[ClientSession] = None
         
@@ -196,20 +196,17 @@ class GitHubMCPClient:
 
 
 def create_github_mcp_client(
-    auth_method: Optional[str] = None,
+    auth_method: str = "oauth",
     github_token: Optional[str] = None
 ) -> GitHubMCPClient:
     """
     Factory function to create a GitHub MCP client.
     
     Args:
-        auth_method: Authentication method ("pat" or "oauth")
-        github_token: GitHub Personal Access Token or OAuth token
+        auth_method: Authentication method ("oauth")
+        github_token: GitHub OAuth token
         
     Returns:
         GitHubMCPClient instance
     """
-    auth_method = auth_method or os.getenv("MCP_AUTH_METHOD", "pat")
-    github_token = github_token or os.getenv("GITHUB_PAT")
-    
     return GitHubMCPClient(auth_method=auth_method, github_token=github_token)

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "lxml>=5.2.2",
     "httpx>=0.27.2",
     "python-dotenv>=1.0.0",
+    "pyjwt>=2.10.1",
 ]
 
 [build-system]

--- a/src/backend/uv.lock
+++ b/src/backend/uv.lock
@@ -39,6 +39,7 @@ dependencies = [
     { name = "mcp" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pydantic" },
+    { name = "pyjwt" },
     { name = "python-dotenv" },
 ]
 
@@ -53,6 +54,7 @@ requires-dist = [
     { name = "mcp", specifier = ">=1.11.0" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2.9" },
     { name = "pydantic", specifier = ">=2.11.7" },
+    { name = "pyjwt", specifier = ">=2.10.1" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
 ]
 
@@ -768,6 +770,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.10.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/46/bd74733ff231675599650d3e47f361794b22ef3e3770998dda30d3b63726/pyjwt-2.10.1.tar.gz", hash = "sha256:3cc5772eb20009233caf06e9d8a0577824723b44e6648ee0a2aedb6cf9381953", size = 87785, upload-time = "2024-11-28T03:43:29.933Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/ad/689f02752eeec26aed679477e80e632ef1b682313be70793d798c1d5fc8f/PyJWT-2.10.1-py3-none-any.whl", hash = "sha256:dcdd193e30abefd5debf142f9adfcdd2b58004e644f25406ffaebd50bd98dacb", size = 22997, upload-time = "2024-11-28T03:43:27.893Z" },
 ]
 
 [[package]]

--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import { Routes, Route } from 'react-router-dom'
+import { AuthProvider } from './contexts/AuthContext'
 import { Header } from './components/Header'
 import { LandingPage } from './components/LandingPage'
 import { PatternsPage } from './components/PatternsPage'
@@ -8,6 +9,8 @@ import { SpecsPage } from './components/SpecsPage'
 import { PatternWorkbench } from './components/PatternWorkbench'
 import { TemplateWorkbench } from './components/TemplateWorkbench'
 import { SpecWorkbench } from './components/SpecWorkbench'
+import { AuthCallback } from './components/AuthCallback'
+import { UserDashboard } from './components/UserDashboard'
 import { Footer } from './components/Footer'
 
 export interface Template {
@@ -110,30 +113,34 @@ function App() {
   }
 
   return (
-    <div className="min-h-screen bg-figma-black font-aptos">
-      <Header />
-      <main>
-        <Routes>
-          <Route path="/" element={<LandingPage />} />
-          <Route path="/patterns" element={<PatternsPage />} />
-          <Route path="/pattern/:patternId" element={<PatternWorkbench />} />
-          <Route path="/templates" element={
-            <TemplatesPage 
-              templates={templates}
-              featuredTemplates={featuredTemplates}
-              filterOptions={filterOptions}
-              filters={filters}
-              onFiltersChange={updateFilters}
-              loading={loading}
-            />
-          } />
-          <Route path="/template/:templateId" element={<TemplateWorkbench />} />
-          <Route path="/specs" element={<SpecsPage />} />
-          <Route path="/spec/:specId" element={<SpecWorkbench />} />
-        </Routes>
-      </main>
-      <Footer />
-    </div>
+    <AuthProvider>
+      <div className="min-h-screen bg-figma-black font-aptos">
+        <Header />
+        <main>
+          <Routes>
+            <Route path="/" element={<LandingPage />} />
+            <Route path="/patterns" element={<PatternsPage />} />
+            <Route path="/pattern/:patternId" element={<PatternWorkbench />} />
+            <Route path="/templates" element={
+              <TemplatesPage 
+                templates={templates}
+                featuredTemplates={featuredTemplates}
+                filterOptions={filterOptions}
+                filters={filters}
+                onFiltersChange={updateFilters}
+                loading={loading}
+              />
+            } />
+            <Route path="/template/:templateId" element={<TemplateWorkbench />} />
+            <Route path="/specs" element={<SpecsPage />} />
+            <Route path="/spec/:specId" element={<SpecWorkbench />} />
+            <Route path="/auth/callback" element={<AuthCallback />} />
+            <Route path="/dashboard" element={<UserDashboard />} />
+          </Routes>
+        </main>
+        <Footer />
+      </div>
+    </AuthProvider>
   )
 }
 

--- a/src/frontend/src/components/AuthCallback.tsx
+++ b/src/frontend/src/components/AuthCallback.tsx
@@ -1,0 +1,70 @@
+import { useEffect, useState } from 'react'
+import { useNavigate, useSearchParams } from 'react-router-dom'
+
+export function AuthCallback() {
+  const [searchParams] = useSearchParams()
+  const navigate = useNavigate()
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const handleCallback = async () => {
+      const code = searchParams.get('code')
+      const error = searchParams.get('error')
+
+      if (error) {
+        setError(`Authentication failed: ${error}`)
+        setLoading(false)
+        return
+      }
+
+      if (!code) {
+        setError('No authorization code received')
+        setLoading(false)
+        return
+      }
+
+      try {
+        const response = await fetch(`${(import.meta as any).env.VITE_API_URL}/api/auth/github/callback`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ code }),
+        })
+
+        if (!response.ok) {
+          throw new Error('Failed to authenticate')
+        }
+
+        const data = await response.json()
+        
+        localStorage.setItem('github_access_token', data.access_token)
+        localStorage.setItem('github_user', JSON.stringify(data.user))
+        
+        navigate('/dashboard')
+      } catch (err) {
+        setError('Authentication failed. Please try again.')
+        console.error('Auth callback error:', err)
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    handleCallback()
+  }, [searchParams, navigate])
+
+  if (loading) {
+    return <div className="flex justify-center items-center min-h-screen">
+      <div className="text-white">Authenticating...</div>
+    </div>
+  }
+
+  if (error) {
+    return <div className="flex justify-center items-center min-h-screen">
+      <div className="text-red-500">{error}</div>
+    </div>
+  }
+
+  return null
+}

--- a/src/frontend/src/components/Header.tsx
+++ b/src/frontend/src/components/Header.tsx
@@ -1,6 +1,10 @@
 import { SEAgentFactoryLogo } from './SEAgentFactoryLogo'
+import { useAuth } from '../contexts/AuthContext'
+import { Link } from 'react-router-dom'
 
 export function Header() {
+  const { user, login, logout, isAuthenticated } = useAuth()
+
   return (
     <header className="bg-figma-black border-b border-figma-medium-gray">
       <div className="max-w-7xl mx-auto px-6 lg:px-8">
@@ -13,6 +17,39 @@ export function Header() {
                 Customize AI solution accelerators for your scenario using SWE Agents
               </span>
             </div>
+          </div>
+          
+          <div className="flex items-center space-x-4">
+            {isAuthenticated ? (
+              <>
+                <Link to="/dashboard">
+                  <button className="text-figma-text-secondary hover:text-figma-text-primary px-3 py-2 rounded-md text-sm font-medium">
+                    Dashboard
+                  </button>
+                </Link>
+                <div className="flex items-center space-x-2">
+                  <img 
+                    src={user?.avatar_url} 
+                    alt={user?.login} 
+                    className="w-8 h-8 rounded-full"
+                  />
+                  <span className="text-figma-text-secondary text-sm">{user?.login}</span>
+                </div>
+                <button 
+                  onClick={logout}
+                  className="text-figma-text-secondary border border-figma-light-gray hover:bg-figma-medium-gray px-3 py-2 rounded-md text-sm font-medium"
+                >
+                  Sign Out
+                </button>
+              </>
+            ) : (
+              <button 
+                onClick={login}
+                className="bg-white text-black hover:bg-gray-200 px-4 py-2 rounded-md text-sm font-medium"
+              >
+                Sign in with GitHub
+              </button>
+            )}
           </div>
         </div>
       </div>

--- a/src/frontend/src/components/PatternWorkbench.tsx
+++ b/src/frontend/src/components/PatternWorkbench.tsx
@@ -386,15 +386,14 @@ export function PatternWorkbench() {
   const assignToSWEAgent = async (taskId?: string) => {
     const { accessToken } = useAuth()
     
-    const authToken = selectedAgent === 'github-copilot' ? accessToken : apiKey
-    if (!selectedAgent || !authToken) return
+    if (!selectedAgent || !accessToken) return
 
     setIsAssigningTasks(true)
     try {
       const mappedCustomization = mapPatternToCustomizationRequest()
       const payload = {
         agent_id: selectedAgent,
-        api_key: authToken,
+        api_key: accessToken,
         template_id: patternId,
         customization: mappedCustomization,
         ...(taskId ? { task_id: taskId } : { 

--- a/src/frontend/src/components/PatternWorkbench.tsx
+++ b/src/frontend/src/components/PatternWorkbench.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from 'react'
 import { useParams, Link } from 'react-router-dom'
+import { useAuth } from '../contexts/AuthContext'
 import mermaid from 'mermaid'
 import { ArrowLeft, Settings, GitBranch, Loader2 } from 'lucide-react'
 import { Button } from './ui/button'
@@ -383,14 +384,17 @@ export function PatternWorkbench() {
   }
 
   const assignToSWEAgent = async (taskId?: string) => {
-    if (!selectedAgent || !apiKey) return
+    const { accessToken } = useAuth()
+    
+    const authToken = selectedAgent === 'github-copilot' ? accessToken : apiKey
+    if (!selectedAgent || !authToken) return
 
     setIsAssigningTasks(true)
     try {
       const mappedCustomization = mapPatternToCustomizationRequest()
       const payload = {
         agent_id: selectedAgent,
-        api_key: apiKey,
+        api_key: authToken,
         template_id: patternId,
         customization: mappedCustomization,
         ...(taskId ? { task_id: taskId } : { 
@@ -654,7 +658,8 @@ export function PatternWorkbench() {
                               <span className="text-figma-text-secondary text-xs">Est. {task.estimatedTokens}</span>
                             </div>
                           </div>
-                        )                        )}
+                        ))}
+
                       </div>
                     )}
                   </div>

--- a/src/frontend/src/components/SWEAgentSelection.tsx
+++ b/src/frontend/src/components/SWEAgentSelection.tsx
@@ -1,11 +1,8 @@
-import { useState } from 'react'
 import { Loader2 } from 'lucide-react'
 import { SiOpenai, SiReplit, SiGithub } from 'react-icons/si'
 import { useAuth } from '../contexts/AuthContext'
 import { Button } from './ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from './ui/card'
-import { Input } from './ui/input'
-import { Label } from './ui/label'
 
 interface SWEAgent {
   id: string
@@ -21,8 +18,6 @@ interface SWEAgent {
 interface SWEAgentSelectionProps {
   selectedAgent: string
   setSelectedAgent: (agent: string) => void
-  apiKey: string
-  setApiKey: (key: string) => void
   customization: any
   workflowMode: 'breakdown' | 'oneshot'
   selectedTasks: Set<string>
@@ -55,8 +50,8 @@ const sweAgents: SWEAgent[] = [
     description: 'Azure OpenAI Codex model with GitHub Actions workflow automation',
     icon: <SiOpenai className="w-6 h-6 text-white" />,
     requiresApiKey: true,
-    configType: 'azure-openai',
-    instructions: 'Deploy Azure OpenAI Codex model at ai.azure.com. Go to Azure AI Studio > Deployments > Create new deployment > Select Codex model. You need the API Key and Endpoint. GitHub Actions workflows will be automatically created for your tasks.'
+    configType: 'oauth',
+    instructions: 'Sign in with GitHub to use Azure OpenAI Codex with GitHub Actions workflow automation.'
   },
   {
     id: 'devin',
@@ -64,24 +59,24 @@ const sweAgents: SWEAgent[] = [
     description: 'Advanced AI software engineer for complex coding tasks',
     icon: <CognitionLogo className="w-6 h-6 text-white" />,
     requiresApiKey: true,
-    configType: 'azure-marketplace',
-    instructions: 'First provision Devin from Azure Marketplace, then get your API key from https://app.devin.ai/settings/api-keys. The API key is required to authenticate with the Devin service for advanced coding tasks.'
+    configType: 'oauth',
+    instructions: 'Sign in with GitHub to deploy Devin for advanced AI software engineering tasks.'
   },
   {
     id: 'replit',
     name: 'Replit Agent',
     description: 'Coming Soon on Azure Marketplace',
     icon: <SiReplit className="w-6 h-6 text-white" />,
-    requiresApiKey: false,
-    comingSoon: true
+    requiresApiKey: true,
+    configType: 'oauth',
+    comingSoon: true,
+    instructions: 'Sign in with GitHub to use Replit Agent for seamless code execution and collaboration.'
   }
 ]
 
 export function SWEAgentSelection({
   selectedAgent,
   setSelectedAgent,
-  apiKey,
-  setApiKey,
   customization,
   workflowMode,
   selectedTasks,
@@ -89,12 +84,9 @@ export function SWEAgentSelection({
   onAssignToSWEAgent,
   validationField
 }: SWEAgentSelectionProps) {
-  const [endpoint, setEndpoint] = useState<string>('')
   const { isAuthenticated, login, user } = useAuth()
 
-  const selectedAgentData = sweAgents.find(a => a.id === selectedAgent)
-  const requiresAuth = selectedAgentData?.configType === 'oauth'
-  const isFormValid = customization[validationField] && (requiresAuth ? isAuthenticated : apiKey)
+  const isFormValid = customization[validationField] && isAuthenticated
 
   return (
     <Card className="bg-figma-medium-gray border-figma-light-gray hover:border-figma-text-secondary transition-colors">
@@ -140,56 +132,14 @@ export function SWEAgentSelection({
             )
           }
           
-          if (agent.configType === 'azure-marketplace') {
-            return (
-              <div className="space-y-3">
-                <div className="p-3 bg-blue-900/20 border border-blue-600 rounded-lg">
-                  <p className="text-blue-400 text-sm font-medium mb-2">Azure Marketplace Setup Required:</p>
-                  <ol className="text-figma-text-primary text-xs space-y-1 list-decimal list-inside">
-                    <li>Provision Devin from Azure Marketplace</li>
-                    <li>Get your API key from <a href="https://app.devin.ai/settings/api-keys" target="_blank" rel="noopener noreferrer" className="text-blue-400 hover:text-blue-300 underline">app.devin.ai/settings/api-keys</a></li>
-                  </ol>
-                </div>
-                <div>
-                  <Label htmlFor="apiKey" className="text-figma-text-primary">Devin API Key</Label>
-                  <Input
-                    id="apiKey"
-                    type="password"
-                    placeholder="Enter your Devin API key..."
-                    value={apiKey}
-                    onChange={(e) => setApiKey(e.target.value)}
-                    className="bg-figma-input-gray border-figma-light-gray text-figma-text-primary placeholder-figma-text-secondary"
-                  />
-                </div>
-                {/* Assignment Button */}
-                <Button
-                  onClick={() => onAssignToSWEAgent()}
-                  disabled={!isFormValid || (workflowMode === 'breakdown' && selectedTasks.size === 0) || isAssigningTasks}
-                  className="w-full bg-white text-black hover:bg-gray-200 border border-gray-300"
-                >
-                  {isAssigningTasks ? (
-                    <>
-                      <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                      Assigning...
-                    </>
-                  ) : (
-                    workflowMode === 'breakdown' 
-                      ? `Assign Selected Tasks (${selectedTasks.size})` 
-                      : 'Assign One-Shot Implementation'
-                  )}
-                </Button>
-              </div>
-            )
-          }
-          
-          if (agent.configType === 'oauth') {
+          if (agent.requiresApiKey) {
             return (
               <div className="space-y-3">
                 {!isAuthenticated ? (
                   <div className="p-4 bg-blue-900/20 border border-blue-600 rounded-lg">
                     <p className="text-blue-400 text-sm font-medium mb-2">GitHub Authentication Required</p>
                     <p className="text-figma-text-secondary text-xs mb-3">
-                      Sign in with GitHub to use GitHub Copilot Coding Agent
+                      Sign in with GitHub to deploy {agent.name} to your repositories
                     </p>
                     <Button
                       onClick={login}
@@ -207,11 +157,11 @@ export function SWEAgentSelection({
                       </p>
                     </div>
                     <p className="text-figma-text-secondary text-xs mt-1">
-                      Ready to use GitHub Copilot with your authenticated account
+                      Ready to deploy {agent.name} to your repositories
                     </p>
                   </div>
                 )}
-
+                
                 <Button
                   onClick={() => onAssignToSWEAgent()}
                   disabled={!isFormValid || (workflowMode === 'breakdown' && selectedTasks.size === 0) || isAssigningTasks}
@@ -232,71 +182,55 @@ export function SWEAgentSelection({
             )
           }
           
-          if (agent.requiresApiKey) {
-            return (
-              <div className="space-y-3">
-                <div>
-                  <Label htmlFor="apiKey" className="text-figma-text-primary">
-                    {agent.configType === 'azure-openai' ? 'API Key & Endpoint' : 'API Key'}
-                  </Label>
-                  <Input
-                    id="apiKey"
-                    type="password"
-                    placeholder={
-                      agent.configType === 'azure-openai' ? 'Enter your Azure OpenAI API Key...' :
-                      'Enter your API key...'
-                    }
-                    value={apiKey}
-                    onChange={(e) => setApiKey(e.target.value)}
-                    className="bg-figma-input-gray border-figma-light-gray text-figma-text-primary placeholder-figma-text-secondary"
-                  />
+          return (
+            <div className="space-y-3">
+              {!isAuthenticated ? (
+                <div className="p-4 bg-blue-900/20 border border-blue-600 rounded-lg">
+                  <p className="text-blue-400 text-sm font-medium mb-2">GitHub Authentication Required</p>
+                  <p className="text-figma-text-secondary text-xs mb-3">
+                    Sign in with GitHub to deploy {agent.name} to your repositories
+                  </p>
+                  <Button
+                    onClick={login}
+                    className="w-full bg-white text-black hover:bg-gray-200"
+                  >
+                    Sign in with GitHub
+                  </Button>
                 </div>
-                
-                {agent.configType === 'azure-openai' && (
-                  <div>
-                    <Label htmlFor="endpoint" className="text-figma-text-primary">Azure OpenAI Endpoint</Label>
-                    <Input
-                      id="endpoint"
-                      type="text"
-                      placeholder="https://your-resource.openai.azure.com/"
-                      value={endpoint}
-                      onChange={(e) => setEndpoint(e.target.value)}
-                      className="bg-figma-input-gray border-figma-light-gray text-figma-text-primary placeholder-figma-text-secondary"
-                    />
+              ) : (
+                <div className="p-3 bg-green-900/20 border border-green-600 rounded-lg">
+                  <div className="flex items-center space-x-2">
+                    <SiGithub className="w-4 h-4 text-green-400" />
+                    <p className="text-green-400 text-sm font-medium">
+                      Authenticated as {user?.login}
+                    </p>
                   </div>
-                )}
-                
-                {agent.instructions && (
-                  <div className="p-3 bg-blue-900/20 border border-blue-600 rounded-lg">
-                    <p className="text-blue-400 text-sm font-medium mb-1">Setup Instructions:</p>
-                    <p className="text-figma-text-primary text-xs">{agent.instructions}</p>
-                  </div>
-                )}
+                  <p className="text-figma-text-secondary text-xs mt-1">
+                    Ready to deploy {agent.name} to your repositories
+                  </p>
+                </div>
+              )}
 
-                {/* Assignment Button */}
-                <Button
-                  onClick={() => onAssignToSWEAgent()}
-                  disabled={!isFormValid || (workflowMode === 'breakdown' && selectedTasks.size === 0) || isAssigningTasks}
-                  className="w-full bg-white text-black hover:bg-gray-200 border border-gray-300"
-                >
-                  {isAssigningTasks ? (
-                    <>
-                      <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                      Assigning...
-                    </>
-                  ) : (
-                    workflowMode === 'breakdown' 
-                      ? `Assign Selected Tasks (${selectedTasks.size})` 
-                      : 'Assign One-Shot Implementation'
-                  )}
-                </Button>
-              </div>
-            )
-          }
-          
-          return null
+              <Button
+                onClick={() => onAssignToSWEAgent()}
+                disabled={!isFormValid || (workflowMode === 'breakdown' && selectedTasks.size === 0) || isAssigningTasks || agent.comingSoon}
+                className="w-full bg-white text-black hover:bg-gray-200 border border-gray-300"
+              >
+                {isAssigningTasks ? (
+                  <>
+                    <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                    Assigning...
+                  </>
+                ) : (
+                  workflowMode === 'breakdown' 
+                    ? `Assign Selected Tasks (${selectedTasks.size})` 
+                    : 'Assign One-Shot Implementation'
+                )}
+              </Button>
+            </div>
+          )
         })()}
       </CardContent>
     </Card>
   )
-}      
+}                      

--- a/src/frontend/src/components/SWEAgentSelection.tsx
+++ b/src/frontend/src/components/SWEAgentSelection.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
-import { ExternalLink, Loader2 } from 'lucide-react'
-import { SiOpenai, SiReplit } from 'react-icons/si'
+import { Loader2 } from 'lucide-react'
+import { SiOpenai, SiReplit, SiGithub } from 'react-icons/si'
+import { useAuth } from '../contexts/AuthContext'
 import { Button } from './ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from './ui/card'
 import { Input } from './ui/input'
@@ -12,7 +13,7 @@ interface SWEAgent {
   description: string
   icon: string | React.ReactNode
   requiresApiKey: boolean
-  configType?: 'api-key' | 'pat' | 'azure-openai' | 'azure-marketplace'
+  configType?: 'api-key' | 'pat' | 'azure-openai' | 'azure-marketplace' | 'oauth'
   instructions?: string
   comingSoon?: boolean
 }
@@ -43,10 +44,10 @@ const sweAgents: SWEAgent[] = [
     id: 'github-copilot',
     name: 'GitHub Copilot Coding Agent',
     description: 'AI pair programmer integrated with GitHub via MCP',
-    icon: <ExternalLink className="w-6 h-6 text-white" />,
+    icon: <SiGithub className="w-6 h-6 text-white" />,
     requiresApiKey: true,
-    configType: 'pat',
-    instructions: 'Generate a Personal Access Token (PAT) from GitHub Settings > Developer settings > Personal access tokens. The agent is invoked via Model Context Protocol (MCP) for seamless integration.'
+    configType: 'oauth',
+    instructions: 'Sign in with GitHub to use GitHub Copilot. The agent is invoked via Model Context Protocol (MCP) for seamless integration.'
   },
   {
     id: 'codex-cli',
@@ -89,8 +90,11 @@ export function SWEAgentSelection({
   validationField
 }: SWEAgentSelectionProps) {
   const [endpoint, setEndpoint] = useState<string>('')
+  const { isAuthenticated, login, user } = useAuth()
 
-  const isFormValid = customization[validationField] && apiKey
+  const selectedAgentData = sweAgents.find(a => a.id === selectedAgent)
+  const requiresAuth = selectedAgentData?.configType === 'oauth'
+  const isFormValid = customization[validationField] && (requiresAuth ? isAuthenticated : apiKey)
 
   return (
     <Card className="bg-figma-medium-gray border-figma-light-gray hover:border-figma-text-secondary transition-colors">
@@ -178,19 +182,67 @@ export function SWEAgentSelection({
             )
           }
           
+          if (agent.configType === 'oauth') {
+            return (
+              <div className="space-y-3">
+                {!isAuthenticated ? (
+                  <div className="p-4 bg-blue-900/20 border border-blue-600 rounded-lg">
+                    <p className="text-blue-400 text-sm font-medium mb-2">GitHub Authentication Required</p>
+                    <p className="text-figma-text-secondary text-xs mb-3">
+                      Sign in with GitHub to use GitHub Copilot Coding Agent
+                    </p>
+                    <Button
+                      onClick={login}
+                      className="w-full bg-white text-black hover:bg-gray-200"
+                    >
+                      Sign in with GitHub
+                    </Button>
+                  </div>
+                ) : (
+                  <div className="p-3 bg-green-900/20 border border-green-600 rounded-lg">
+                    <div className="flex items-center space-x-2">
+                      <SiGithub className="w-4 h-4 text-green-400" />
+                      <p className="text-green-400 text-sm font-medium">
+                        Authenticated as {user?.login}
+                      </p>
+                    </div>
+                    <p className="text-figma-text-secondary text-xs mt-1">
+                      Ready to use GitHub Copilot with your authenticated account
+                    </p>
+                  </div>
+                )}
+
+                <Button
+                  onClick={() => onAssignToSWEAgent()}
+                  disabled={!isFormValid || (workflowMode === 'breakdown' && selectedTasks.size === 0) || isAssigningTasks}
+                  className="w-full bg-white text-black hover:bg-gray-200 border border-gray-300"
+                >
+                  {isAssigningTasks ? (
+                    <>
+                      <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                      Assigning...
+                    </>
+                  ) : (
+                    workflowMode === 'breakdown' 
+                      ? `Assign Selected Tasks (${selectedTasks.size})` 
+                      : 'Assign One-Shot Implementation'
+                  )}
+                </Button>
+              </div>
+            )
+          }
+          
           if (agent.requiresApiKey) {
             return (
               <div className="space-y-3">
                 <div>
                   <Label htmlFor="apiKey" className="text-figma-text-primary">
-                    {agent.configType === 'pat' ? 'Personal Access Token (PAT)' : 
-                     agent.configType === 'azure-openai' ? 'API Key & Endpoint' : 'API Key'}
+                    {agent.configType === 'azure-openai' ? 'API Key & Endpoint' : 'API Key'}
                   </Label>
                   <Input
                     id="apiKey"
                     type="password"
                     placeholder={
-                      agent.configType === 'pat' ? 'Enter your GitHub PAT...' :
                       agent.configType === 'azure-openai' ? 'Enter your Azure OpenAI API Key...' :
                       'Enter your API key...'
                     }
@@ -247,4 +299,4 @@ export function SWEAgentSelection({
       </CardContent>
     </Card>
   )
-} 
+}      

--- a/src/frontend/src/components/SpecWorkbench.tsx
+++ b/src/frontend/src/components/SpecWorkbench.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react'
 import { useParams, Link, useNavigate } from 'react-router-dom'
+import { useAuth } from '../contexts/AuthContext'
 import { ArrowLeft, Settings, GitBranch, Loader2, Save, FileText } from 'lucide-react'
 import { Button } from './ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from './ui/card'
@@ -185,7 +186,10 @@ export function SpecWorkbench() {
   }
 
   const assignToSWEAgent = async (taskId?: string) => {
-    if (!selectedAgent || !apiKey) return
+    const { accessToken } = useAuth()
+    
+    const authToken = selectedAgent === 'github-copilot' ? accessToken : apiKey
+    if (!selectedAgent || !authToken) return
 
     setIsAssigningTasks(true)
     try {
@@ -198,7 +202,7 @@ export function SpecWorkbench() {
 
       const payload = {
         agent_id: selectedAgent,
-        api_key: apiKey,
+        api_key: authToken,
         template_id: spec?.id || specId,
         customization: mappedCustomization,
         ...(taskId ? { task_id: taskId } : { 

--- a/src/frontend/src/components/SpecWorkbench.tsx
+++ b/src/frontend/src/components/SpecWorkbench.tsx
@@ -188,8 +188,7 @@ export function SpecWorkbench() {
   const assignToSWEAgent = async (taskId?: string) => {
     const { accessToken } = useAuth()
     
-    const authToken = selectedAgent === 'github-copilot' ? accessToken : apiKey
-    if (!selectedAgent || !authToken) return
+    if (!selectedAgent || !accessToken) return
 
     setIsAssigningTasks(true)
     try {
@@ -202,7 +201,7 @@ export function SpecWorkbench() {
 
       const payload = {
         agent_id: selectedAgent,
-        api_key: authToken,
+        api_key: accessToken,
         template_id: spec?.id || specId,
         customization: mappedCustomization,
         ...(taskId ? { task_id: taskId } : { 

--- a/src/frontend/src/components/TemplateWorkbench.tsx
+++ b/src/frontend/src/components/TemplateWorkbench.tsx
@@ -118,14 +118,13 @@ export function TemplateWorkbench() {
   const assignToSWEAgent = async (taskId?: string) => {
     const { accessToken } = useAuth()
     
-    const authToken = selectedAgent === 'github-copilot' ? accessToken : apiKey
-    if (!selectedAgent || !authToken) return
+    if (!selectedAgent || !accessToken) return
 
     setIsAssigningTasks(true)
     try {
       const payload = {
         agent_id: selectedAgent,
-        api_key: authToken,
+        api_key: accessToken,
         template_id: templateId,
         customization,
         ...(taskId ? { task_id: taskId } : { 

--- a/src/frontend/src/components/TemplateWorkbench.tsx
+++ b/src/frontend/src/components/TemplateWorkbench.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useParams, Link } from 'react-router-dom'
+import { useAuth } from '../contexts/AuthContext'
 import { ArrowLeft, Settings, GitBranch, Loader2 } from 'lucide-react'
 import { Button } from './ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from './ui/card'
@@ -115,13 +116,16 @@ export function TemplateWorkbench() {
   }
 
   const assignToSWEAgent = async (taskId?: string) => {
-    if (!selectedAgent || !apiKey) return
+    const { accessToken } = useAuth()
+    
+    const authToken = selectedAgent === 'github-copilot' ? accessToken : apiKey
+    if (!selectedAgent || !authToken) return
 
     setIsAssigningTasks(true)
     try {
       const payload = {
         agent_id: selectedAgent,
-        api_key: apiKey,
+        api_key: authToken,
         template_id: templateId,
         customization,
         ...(taskId ? { task_id: taskId } : { 
@@ -534,3 +538,5 @@ export function TemplateWorkbench() {
     </div>
   )
 }
+
+export default TemplateWorkbench

--- a/src/frontend/src/components/UserDashboard.tsx
+++ b/src/frontend/src/components/UserDashboard.tsx
@@ -1,0 +1,141 @@
+import { useState, useEffect } from 'react'
+import { useAuth } from '../contexts/AuthContext'
+import { Link } from 'react-router-dom'
+
+interface Repository {
+  id: number
+  name: string
+  full_name: string
+  description: string
+  html_url: string
+  stargazers_count: number
+  forks_count: number
+  updated_at: string
+  private: boolean
+}
+
+export function UserDashboard() {
+  const { user, accessToken, isAuthenticated } = useAuth()
+  const [repositories, setRepositories] = useState<Repository[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    if (isAuthenticated && accessToken) {
+      fetchRepositories()
+    }
+  }, [isAuthenticated, accessToken])
+
+  const fetchRepositories = async () => {
+    try {
+      const response = await fetch(`${(import.meta as any).env.VITE_API_URL}/api/user/repositories`, {
+        headers: {
+          'Authorization': `Bearer ${accessToken}`
+        }
+      })
+      
+      if (response.ok) {
+        const data = await response.json()
+        setRepositories(data)
+      }
+    } catch (error) {
+      console.error('Failed to fetch repositories:', error)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  if (!isAuthenticated) {
+    return (
+      <div className="min-h-screen bg-figma-black flex items-center justify-center">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold text-figma-text-primary mb-4">
+            Please sign in to view your dashboard
+          </h1>
+          <p className="text-figma-text-secondary">
+            Sign in with GitHub to deploy AI agents to your repositories
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-figma-black py-8">
+      <div className="max-w-7xl mx-auto px-6 lg:px-8">
+        <div className="mb-8">
+          <h1 className="text-3xl font-bold text-figma-text-primary mb-2">
+            Welcome back, {user?.name || user?.login}!
+          </h1>
+          <p className="text-figma-text-secondary">
+            Deploy AI agents to your GitHub repositories and manage your automated workflows
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+          <div>
+            <h2 className="text-xl font-semibold text-figma-text-primary mb-4">
+              Your Repositories
+            </h2>
+            {loading ? (
+              <div className="text-figma-text-secondary">Loading repositories...</div>
+            ) : (
+              <div className="space-y-4">
+                {repositories.slice(0, 10).map((repo) => (
+                  <div key={repo.id} className="bg-figma-medium-gray border border-figma-light-gray rounded-lg p-4">
+                    <div className="mb-3">
+                      <h3 className="text-figma-text-primary text-lg font-medium">
+                        {repo.name}
+                      </h3>
+                      <p className="text-figma-text-secondary text-sm">
+                        {repo.description || 'No description available'}
+                      </p>
+                    </div>
+                    <div className="flex items-center justify-between">
+                      <div className="flex items-center space-x-4 text-sm text-figma-text-secondary">
+                        <div className="flex items-center space-x-1">
+                          <span>⭐</span>
+                          <span>{repo.stargazers_count}</span>
+                        </div>
+                        <div className="flex items-center space-x-1">
+                          <span>🍴</span>
+                          <span>{repo.forks_count}</span>
+                        </div>
+                        <div className="flex items-center space-x-1">
+                          <span>📅</span>
+                          <span>{new Date(repo.updated_at).toLocaleDateString()}</span>
+                        </div>
+                      </div>
+                      <button 
+                        className="text-figma-text-secondary border border-figma-light-gray hover:bg-figma-light-gray px-3 py-1 rounded text-sm"
+                        onClick={() => window.open(repo.html_url, '_blank')}
+                      >
+                        View on GitHub
+                      </button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+
+          <div>
+            <h2 className="text-xl font-semibold text-figma-text-primary mb-4">
+              Deployed Agents
+            </h2>
+            <div className="bg-figma-medium-gray border border-figma-light-gray rounded-lg p-6">
+              <div className="text-center text-figma-text-secondary">
+                <p>No agents deployed yet.</p>
+                <p className="mt-2">Browse templates and deploy your first AI agent!</p>
+                <Link to="/templates">
+                  <button className="mt-4 bg-white text-black hover:bg-gray-200 px-4 py-2 rounded-md">
+                    Browse Templates
+                  </button>
+                </Link>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/frontend/src/contexts/AuthContext.tsx
+++ b/src/frontend/src/contexts/AuthContext.tsx
@@ -1,0 +1,71 @@
+import React, { createContext, useContext, useState, useEffect } from 'react'
+
+interface User {
+  login: string
+  name?: string
+  avatar_url: string
+}
+
+interface AuthContextType {
+  user: User | null
+  accessToken: string | null
+  login: () => void
+  logout: () => void
+  isAuthenticated: boolean
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined)
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [user, setUser] = useState<User | null>(null)
+  const [accessToken, setAccessToken] = useState<string | null>(null)
+
+  useEffect(() => {
+    const storedToken = localStorage.getItem('github_access_token')
+    const storedUser = localStorage.getItem('github_user')
+    
+    if (storedToken && storedUser) {
+      setAccessToken(storedToken)
+      setUser(JSON.parse(storedUser))
+    }
+  }, [])
+
+  const login = async () => {
+    try {
+      const response = await fetch(`${(import.meta as any).env.VITE_API_URL}/api/auth/github`)
+      const data = await response.json()
+      window.location.href = data.auth_url
+    } catch (error) {
+      console.error('Login failed:', error)
+    }
+  }
+
+  const logout = () => {
+    setUser(null)
+    setAccessToken(null)
+    localStorage.removeItem('github_access_token')
+    localStorage.removeItem('github_user')
+  }
+
+  const value = {
+    user,
+    accessToken,
+    login,
+    logout,
+    isAuthenticated: !!user && !!accessToken
+  }
+
+  return (
+    <AuthContext.Provider value={value}>
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+export function useAuth() {
+  const context = useContext(AuthContext)
+  if (context === undefined) {
+    throw new Error('useAuth must be used within an AuthProvider')
+  }
+  return context
+}


### PR DESCRIPTION
# Extend GitHub OAuth requirement to ALL agents in SWE Agent Selection

## Summary

This PR implements a comprehensive GitHub OAuth authentication system and standardizes the SWE Agent Selection component across all pages to require GitHub authentication for **ALL** agents (not just GitHub Copilot). The changes transform the platform from API key-based authentication to OAuth-based authentication for repository operations.

**Key Changes:**
- **GitHub App Integration**: Added complete OAuth flow with GitHub App authentication
- **Unified Authentication**: ALL agents (GitHub Copilot, Azure OpenAI Codex, Devin, Replit) now require GitHub OAuth
- **Standardized Component**: SWE Agent Selection component works consistently across templates, specs, and patterns pages
- **Removed API Keys**: Eliminated all API key input fields since all agents need repository operations
- **Updated Backend**: Modified agent assignment logic to use OAuth tokens uniformly

## Review & Testing Checklist for Human

**Critical Items (5 items - HIGH RISK):**

- [ ] **Test complete OAuth flow end-to-end**: Sign in → GitHub authorization → callback → token storage → authenticated state across all pages
- [ ] **Verify ALL agents require GitHub auth**: Test each agent (Codex, Devin, Replit, GitHub Copilot) on all three pages (templates, specs, patterns) - should show "Sign in with GitHub" when unauthenticated
- [ ] **Test agent assignment functionality**: After authentication, verify that agent assignments work correctly with OAuth tokens instead of API keys
- [ ] **Validate environment configuration**: Ensure `GITHUB_CLIENT_SECRET` and private key path are properly configured in production environment
- [ ] **Check for API key remnants**: Verify no API key input fields remain anywhere in the UI and that all backend logic uses OAuth tokens

### Test Plan Recommendations:
1. **Unauthenticated state**: Navigate to each page (templates, specs, patterns), select different agents, confirm all show GitHub sign-in prompt
2. **Authentication flow**: Complete GitHub OAuth sign-in, verify redirect works, check token persistence across browser sessions
3. **Authenticated state**: After sign-in, test agent selection and assignment on all pages
4. **Error handling**: Test with invalid tokens, network failures, and GitHub API errors

### Notes

**Environment Setup Required:**
- `GITHUB_CLIENT_SECRET` must be configured (not in code for security)
- Private key file path must be accessible at configured location
- Redirect URI must match GitHub App configuration (`http://localhost:5173/auth/callback`)

**Architecture Changes:**
- Frontend now uses AuthContext for global authentication state
- Backend always uses `auth_method="oauth"` for MCP client
- All workbench components updated to pass `accessToken` instead of `apiKey`

**Link to Devin run:** https://app.devin.ai/sessions/9cc062bcf9b0418886ed47217e8f1ba8
**Requested by:** @thegovind